### PR TITLE
Added Good-GitHub-Issues

### DIFF
--- a/Good-GitHub-Issues.md
+++ b/Good-GitHub-Issues.md
@@ -1,0 +1,41 @@
+# Writing Good GitHub Issues
+
+GitHub issues are where dicussions about open source projects happen. Getting good at writing GitHub issues will get you more help building your projects as well as improve your practice of building open source.
+
+Good issues will get you more help by making it easy for outside contributors to understand your project and help you out.
+
+Good issues are also professional development. Many technology and [government](https://18f.gsa.gov/) jobs have a remote first work style where all conversations happen online in tools like GitHub issues. Having a public trail of well formed issues can help get you paid.  :moneybag::moneybag::moneybag:
+
+#### Example
+A favorite [example](https://github.com/codeforamerica/brigade/issues/344).
+
+It clearly describes what is going on, includes relevant user research, points to the necessary files, and has a checklist of actions to take. The conversation is pretty good too, with lots of code samples and references to the issue from commits.
+
+#### Sections
+Common sections to include in your issue. Don't go overboard, just use what you need.
+```
+#### Description
+#### Screenshots
+#### To Reproduce
+#### Files
+#### Tasks
+```
+
+#### Template
+To easily start a new issue with all of these sections, use this [template](https://github.com/codeforamerica/howto/issues/new?title=Descriptive+issue+title&body=%23%23%23%23+Description%0AA+clear+and+concise+description+of+what+the+issue+is+about.%0A%0A%23%23%23%23+Screenshots%0A![Downhill+Windmills](http://i.giphy.com/KO8AG2EByqkFi.gif)%0A%0A%23%23%23%23+Files%0AA+list+of+relevant+files+for+this+issue.+This+will+help+peole+navigate+the+project+and+offer+some+clues+of+where+to+start.%0A%0A%23%23%23%23+To+Reproduce%0AIf+this+issue+is+describing+a+bug,+include+some+steps+to+reproduce+the+behavior.%0A%23%23%23%23+Tasks%0AInclude+specific+tasks+in+the+order+they+need+to+be+done+in.+Include+links+to+specific+lines+of+code+where+the+task+should+happen+at.%0A-+[+]+Task+1%0A-+[+]+Task+2%0A-+[+]+Task+3%0A%0ARemember+to+use+helpful+labels+and+milestones.+If+you+use+the+%22help+wanted%22+label,+Code+for+America+will+promote+it+widely.)
+
+
+#### Labels
+GitHub [labels](https://github.com/codeforamerica/howto/labels) are a quick way to categorize your issues. `bug` and `enhancement` are really useful when trying to organize your sprints. We'll often add new labels such as `python` or `design` if want to make it clear what skills are needed to help with that issue.
+
+#### Help Wanted
+Code for America has built some tools that make the `help wanted` label special. If you label your issue with `help wanted` we'll promote it widely using the [Civic Issue Finder](http://www.codeforamerica.org/geeks/civicissues) and other tools. These tools get lots of attention, so use them to get helpful PRs from strangers.
+
+#### Milestones
+Milestones are useful way to group issues together with a due date. Here is an [example](https://github.com/codeforamerica/cfapi/issues?q=is%3Aissue+milestone%3Aattendance+is%3Aclosed). 
+
+GitHub has [a useful guide](https://guides.github.com/features/issues/) that goes even deeper.
+
+
+
+


### PR DESCRIPTION
Wrote a guide for writing GitHub issues that are easily accessible to new contributors.

I'm particularly proud of the [issue template](https://github.com/codeforamerica/howto/issues/new?title=Descriptive+issue+title&body=%23%23%23%23+Description%0AA+clear+and+concise+description+of+what+the+issue+is+about.%0A%0A%23%23%23%23+Screenshots%0A![Downhill+Windmills](http://i.giphy.com/KO8AG2EByqkFi.gif)%0A%0A%23%23%23%23+Files%0AA+list+of+relevant+files+for+this+issue.+This+will+help+peole+navigate+the+project+and+offer+some+clues+of+where+to+start.%0A%0A%23%23%23%23+To+Reproduce%0AIf+this+issue+is+describing+a+bug,+include+some+steps+to+reproduce+the+behavior.%0A%23%23%23%23+Tasks%0AInclude+specific+tasks+in+the+order+they+need+to+be+done+in.+Include+links+to+specific+lines+of+code+where+the+task+should+happen+at.%0A-+[+]+Task+1%0A-+[+]+Task+2%0A-+[+]+Task+3%0A%0ARemember+to+use+helpful+labels+and+milestones.+If+you+use+the+%22help+wanted%22+label,+Code+for+America+will+promote+it+widely.) I made.

Any improvements you suggest?